### PR TITLE
try hardcoding tailwind classes

### DIFF
--- a/src/components/skills/SkillList.astro
+++ b/src/components/skills/SkillList.astro
@@ -15,7 +15,7 @@ let colorOverrides: { [key: string]: string } = {
         badges.map((Badge) => {
             return (
                 <div
-                    class={`h-[${size}] w-[${size}] hover:scale-110`}
+                    class="h-[3rem] w-[3rem] hover:scale-110"
                     transition:name={Badge.name}
                 >
                     {Badge.name in colorOverrides ? (


### PR DESCRIPTION
there was some weirdness with the classes causing disappearing icons, which is weirdly only occuring in prod. Before reverting, trying returning to hardcoded tailwind classes to see if it makes a difference.