### PR TITLE
F/rework nav underlines

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -39,7 +39,7 @@ const alongPath = (path: string) => {
 
 <nav class="flex h-12 w-full items-center justify-between bg-slate-800 px-3">
     <div class="flex h-full w-auto">
-        <a href="/" class="flex items-center">
+        <a href="/" class="flex items-center" draggable="false">
             <Image
                 src={blingus}
                 alt="blingus"
@@ -60,7 +60,9 @@ const alongPath = (path: string) => {
                     return (
                         <div class="flex flex-col">
                             <div>
-                                <a href={item.path}>{item.label}</a>
+                                <a href={item.path} draggable="false">
+                                    {item.label}
+                                </a>
                             </div>
                             <div class="h-1 w-full" />
                         </div>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -25,11 +25,16 @@ const navItems = [
     },
 ];
 
-interface Props {
-    path?: string;
-    title: string;
-}
-const { path, title } = Astro.props;
+const alongPath = (path: string) => {
+    const { pathname } = Astro.url;
+    const pathRe = /\/\w*/;
+
+    const p1 = path.match(pathRe)![0];
+    const p2 = pathname.match(pathRe)![0];
+
+    if (!p1 || !p2) return false;
+    return p1 === p2;
+};
 ---
 
 <nav class="flex h-12 w-full items-center justify-between bg-slate-800 px-3">
@@ -49,7 +54,7 @@ const { path, title } = Astro.props;
     <div class="hidden gap-5 p-3 xs:flex">
         {
             navItems.map((item) => {
-                let active = item.label === title;
+                let active = alongPath(item.path);
 
                 if (!active) {
                     return (

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -71,7 +71,9 @@ const alongPath = (path: string) => {
                 return (
                     <div class="flex flex-col">
                         <div>
-                            <a href={item.path}>{item.label}</a>
+                            <a href={item.path} draggable="false">
+                                {item.label}
+                            </a>
                         </div>
                         <div
                             class="h-0.5 w-full rounded-s bg-sky-300"

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -4,9 +4,8 @@ import Footer from "../components/Footer.astro";
 import { ViewTransitions } from "astro:transitions";
 interface Props {
     title: string;
-    path?: string;
 }
-const { title, path } = Astro.props;
+const { title } = Astro.props;
 ---
 
 <!doctype html>
@@ -29,7 +28,7 @@ const { title, path } = Astro.props;
     </head>
     <body class="flex min-h-screen w-full flex-col justify-between">
         <header class="flex w-full">
-            <Nav title={title} />
+            <Nav />
         </header>
 
         <div class="flex grow flex-col">

--- a/src/layouts/TextPage.astro
+++ b/src/layouts/TextPage.astro
@@ -4,8 +4,8 @@ import Layout from "./Layout.astro";
 const { title = "Blingusblongus", path } = Astro.props;
 ---
 
-<Layout title={title} path={path} transition:name="test-title">
-    <div class:list={["sm:w-5/6 m-auto px-3 max-w-2xl mt-[3rem]"]}>
+<Layout title={title} transition:name="test-title">
+    <div class:list={["m-auto mt-[3rem] max-w-2xl px-3 sm:w-5/6"]}>
         <article
             class="prose prose-invert lg:prose-lg prose-headings:mt-[3rem] prose-a:text-gray-400 hover:prose-a:text-sky-300"
         >

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -6,7 +6,7 @@ import "../assets/styles/about.module.css";
 const { Content, frontmatter } = page;
 ---
 
-<TextPage title="About" path="/about">
+<TextPage title="About">
     <h1>
         <span transition:name="about-title" class="text-center">
             {frontmatter.title}

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -5,7 +5,7 @@ import "../assets/styles/about.module.css";
 import Content from "../components/Content.astro";
 ---
 
-<Layout title="Blog" path="/blog">
+<Layout title="Blog">
     <Content>
         <article
             class="prose prose-invert lg:prose-lg prose-headings:mt-[3rem]"
@@ -17,7 +17,7 @@ import Content from "../components/Content.astro";
             </h1>
 
             <div
-                class="w-full h-full"
+                class="h-full w-full"
                 transition:animate={slide({ duration: 500 })}
             >
                 {"Coming soon <3"}

--- a/src/pages/code.astro
+++ b/src/pages/code.astro
@@ -6,12 +6,12 @@ import "../assets/styles/about.module.css";
 const { Content, frontmatter } = page;
 ---
 
-<TextPage title={frontmatter.title} path="/code">
+<TextPage title={frontmatter.title}>
     <h1>
         <span transition:name="code-title">{frontmatter.title}</span>
     </h1>
 
-    <div class="w-full h-full" transition:animate={slide({ duration: 500 })}>
+    <div class="h-full w-full" transition:animate={slide({ duration: 500 })}>
         <Content />
     </div>
 </TextPage>

--- a/src/pages/experience.astro
+++ b/src/pages/experience.astro
@@ -6,7 +6,7 @@ import "../assets/styles/about.module.css";
 const { Content, frontmatter } = page;
 ---
 
-<TextPage title={frontmatter.title} path="/experience">
+<TextPage title={frontmatter.title}>
     <h1>
         <span transition:name="experience-title">{frontmatter.title}</span>
     </h1>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -79,7 +79,7 @@ import { allBadges } from "../components/skills/skillList.data.astro";
         >
             <div class="mx-auto">
                 <h1 class="text-4xl font-bold">
-                    <a href="/skills/all">
+                    <a href="/skills/all" draggable="false">
                         <span transition:name="skills-title">Skills</span>
                     </a>
                 </h1>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,7 +12,7 @@ import { allBadges } from "../components/skills/skillList.data.astro";
 ---
 
 <Layout title="Home">
-    <div <main>
+    <main>
         <section class="relative w-screen">
             <Image
                 src={squid}
@@ -92,5 +92,5 @@ import { allBadges } from "../components/skills/skillList.data.astro";
         </section>
 
         <ContactMe />
-    </div>
+    </main>
 </Layout>

--- a/src/pages/skills/[sort].astro
+++ b/src/pages/skills/[sort].astro
@@ -21,7 +21,7 @@ export async function getStaticPaths() {
 const { sort } = Astro.params;
 ---
 
-<Layout title="Skills" path="/skills">
+<Layout title="Skills">
     <SkillsLayout path={`/${sort}`}>
         {
             sort === "lovelikemeh" && (


### PR DESCRIPTION
Closes #8 , #24.

- Reworks underlines to use `Astro.url.pathname` instead of explicit props.
- Removes draggable links from major nav links.